### PR TITLE
Integration with cwrc_citeproc module

### DIFF
--- a/includes/classes/CwrcSolrResultsBibliographicView.php
+++ b/includes/classes/CwrcSolrResultsBibliographicView.php
@@ -47,11 +47,36 @@ class CwrcSolrResultsBibliographicView extends CwrcSolrResults {
     $layouts = $this->getCslLayouts();
     $layout = (isset($_GET['layout']) && isset($layouts[$_GET['layout']])) ? $_GET['layout'] : drupal_html_class(CSL::GetDefaultName());
 
-    // Very simple display here, just list names with labels.
+    $cwrc_citeproc_module = module_exists('cwrc_citeproc');
+    $result_items = array();
     foreach ($solr_results['response']['objects'] as $solr_result) {
-      $mods = islandora_datastream_load('MODS', $solr_result['PID']);
-      $rendered = citeproc_bibliography_from_mods(citeproc_style($layouts[$layout]), $mods->content);
-      $results[] = l($rendered, 'islandora/object/' . $solr_result['PID'], array('html' => TRUE));
+      $link_options = array('html' => TRUE);
+      $object_id = $solr_result['PID'];
+      $mods = islandora_datastream_load('MODS', $object_id);
+      if ($cwrc_citeproc_module) {
+        $result_items[$object_id] = $mods->content;
+        // Placeholder text.
+        $rendered = t('<div id="@id">@label</div>', array(
+          '@id' => 'cwrc-citeproc-bibliography-wrapper-' . drupal_clean_css_identifier($object_id),
+          '@label' => $solr_result['object_label'],
+        ));
+        $link_options['attributes']['class'][] = 'clearfix';
+        $link_options['attributes']['title'] = t('View @label', array(
+          '@label' => $solr_result['object_label'],
+        ));
+      }
+      else {
+        // Very simple display here, just list names with labels.
+        $rendered = citeproc_bibliography_from_mods(citeproc_style($layouts[$layout]), $mods->content);
+      }
+      $results[] = l($rendered, 'islandora/object/' . $object_id, $link_options);
+    }
+
+    if ($cwrc_citeproc_module && $result_items) {
+      $cwrc_citeproc_js = array(
+        '#attached' => _cwrc_citeproc_get_js_attach($layouts[$layout], $result_items),
+      );
+      drupal_render($cwrc_citeproc_js);
     }
 
     // Return themed search results.


### PR DESCRIPTION
# Problem / motivation

The current rendering of citation/bibliography through islandora is incorrect. We have created a module, https://github.com/cwrc/cwrc_citeproc, which will alter some of the existing functionalities to render properly the citation. See https://trello.com/c/6snB8KXS/108-citations-multiple-mods-to-citation-style-transformation-issues for more details.

# Proposed resolution

Added an integration with https://github.com/cwrc/cwrc_citeproc when it will be enabled. This pull request can be merge if everything else is ok and the search result will stay the same until cwrc_citeproc is deployed and enabled.

# Remaining tasks

- [ ] Code review
- [ ] Commit
- [ ] Merge

# User interface changes

The desired citation/bibliography would be used.
